### PR TITLE
Add CI/CD to automatically open a PR in the generated project for changes in the cookiecutter

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ the following features:
         - Auto-converts Jupyter notebooks in `nbexamples`
 - Auto-merges pull requests by maintainers
 - Auto-drafts release notes based on merged pull requests
+- Syncs new changes from the cookiecutter template using `cruft`
+on a cron workflow. Creates a PR with the changes to be merged
+manually.
 - Collects TODO comments and converts them into issues (optional)
 - Closes TODO issues once comments are removed (optional)
 
@@ -122,6 +125,9 @@ repo settings:
 - `no auto merge`: added to prevent automatic merging of 
 pull requests by maintainers
 - `maintenance`: one of the output categories for release notes
+- `automated pr`: Used by automated template update cron workflow which
+uses `cruft` to check for changes in the template and opens a PR
+automatically if so.
 
 #### Set Master to Protected Branch
 
@@ -214,6 +220,23 @@ Navigate to the repo base folder and run:
 ```
 pipenv run python upload.py
 ```
+
+### Updating Build Requirements
+
+The Github Actions CI/CD uses `Pipfile.lock` to install its 
+requirements. Run `pipenv update` locally to update the 
+`Pipfile.lock` with the newest dependencies and push into
+the `master` branch to get the dependencies updated
+on the CI/CD system.
+
+### Syncing with the `cookiecutter` template
+
+There is a built-in workflow which runs daily to check for
+updates in the `cookiecutter` template. If it finds an update,
+it will use `cruft` to apply the update and raise a PR with the
+changes. Manually review the changes, adjusting if needed, then
+merge the PR to keep updated with the template.
+
 
 ## Links
 

--- a/{{cookiecutter.repo_name}}/.github/workflows/template-update.yml
+++ b/{{cookiecutter.repo_name}}/.github/workflows/template-update.yml
@@ -1,0 +1,64 @@
+{% raw %}
+name: Update Template using Cruft
+
+on:
+  schedule:
+    - cron: "0 3 * * *"  # every day at 3:00 AM
+
+
+jobs:
+  templateUpdate:
+
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 1
+      matrix:
+        python-version: [3.7]
+
+    steps:
+    - uses: actions/checkout@v2
+      ref: master
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install Pipenv
+      uses: dschep/install-pipenv-action@v1
+    - name: Install dependencies
+      run: |
+        pipenv sync
+    - name: Check if template is out of date
+      id: template_check
+      run: |
+        if ! pipenv run cruft check; then
+          echo "Need to update template. Will do so and open PR.";
+          echo ::set-output name=template_update::true;
+        else
+          echo "No updates to template needed, will exit workflow.";
+          echo ::set-output name=template_update::false;
+        fi;
+    - name: Template Update
+      if: steps.template_check.outputs.template_update == 'true'
+      run: pipenv run cruft update -s;
+    - name: Create PR with template update
+      if: steps.template_check.outputs.template_update == 'true'
+      uses: peter-evans/create-pull-request@v2
+      with:
+        token: ${{ secrets.gh_token }}
+        commit-message: Update template from Cookiecutter using Cruft
+        author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+        committer: GitHub <noreply@github.com>
+        title: 'Update template from Cookiecutter using Cruft'
+        body: |
+          Update template from Cookiecutter using Cruft.
+
+          Before merging, review the changes and adjust manually if necessary. Especially look for
+          new files ending with `.orig` being added as this signifies a merge conflict that
+          needs to be resolved.
+
+          - Updates coming from [cookiecutter-pypi-sphinx][1]
+
+          [1]: https://github.com/whoopnip/cookiecutter-pypi-sphinx
+        labels: no auto merge, automated pr
+        branch: template-patches
+{% endraw %}

--- a/{{cookiecutter.repo_name}}/conf.py
+++ b/{{cookiecutter.repo_name}}/conf.py
@@ -110,7 +110,7 @@ PACKAGE_URLS = {
 
 # Does not affect anything about the current package. Simply used for tracking when this repo was created off
 # of the quickstart template, so it is easier to bring over new changes to the template.
-_TEMPLATE_VERSION_TUPLE = (0, 5, 1)
+_TEMPLATE_VERSION_TUPLE = (0, 5, 2)
 
 if __name__ == '__main__':
     # Store config as environment variables


### PR DESCRIPTION
Uses Github Actions to run `cruft check` on a daily basis. Once `cruft check` fails, then it will use `cruft update` to get the update and open a PR with the changes. Then it is up to the author to manually review and merge the changes.