### PR TITLE
Fix bugs with checkout syntax and cron syntax in template update workflow

### DIFF
--- a/{{cookiecutter.repo_name}}/.github/workflows/template-update.yml
+++ b/{{cookiecutter.repo_name}}/.github/workflows/template-update.yml
@@ -3,7 +3,7 @@ name: Update Template using Cruft
 
 on:
   schedule:
-    - cron: "0 3 * * *"  # every day at 3:00 AM
+    - cron: '0 3 * * *'  # every day at 3:00 AM
 
 
 jobs:
@@ -17,7 +17,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-      ref: master
+      with:
+        ref: master
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
       with:


### PR DESCRIPTION
These issues were keeping the template update from running.